### PR TITLE
Feature metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.DS_Store
 __pycache__/
 experiments/
+exp/
 alfred/
 archive/
 mortimer/web_experiments/change_names.py

--- a/mortimer/forms.py
+++ b/mortimer/forms.py
@@ -77,12 +77,12 @@ class UpdateAccountForm(FlaskForm):
 
 class WebExperimentForm(FlaskForm):
     title = StringField("Title", validators=[DataRequired()])
+    version = StringField("Version", validators=[DataRequired()])
     description = TextAreaField("Description")
     password = StringField("Password")
     script = FileField("script.py", validators=[FileAllowed(['py'])])
 
     def validate_title(self, title):
-
         experiment = WebExperiment.objects(
             title__exact=title.data,
             author__exact=current_user.username).first()
@@ -95,6 +95,12 @@ class WebExperimentForm(FlaskForm):
                 re.match("script.py", script.data.filename)):
             raise ValidationError(
                 "Your script file needs to be called \'script.py\'.")
+
+    def validate_version(self, version):
+        try:
+            int(version.data.replace(".", ""))
+        except Exception:
+            raise ValidationError("Please use only points and digits for the version number. Example: '1.3.2'")
 
     submit = SubmitField("Create")
 
@@ -120,18 +126,32 @@ class UpdateExperimentForm(FlaskForm):
     description = TextAreaField("Description")
     password = StringField("Password")
     script = TextAreaField("Script")
+    version = StringField("Updated version", validators=[DataRequired()])
+
+    def validate_version(self, version):
+        try:
+            int(version.data.replace(".", ""))
+        except Exception:
+            raise ValidationError("Please use only points and digits for the version number. Example: '1.3.2'")
 
     submit = SubmitField("Update")
 
 
 class NewScriptForm(FlaskForm):
     script = FileField("Update script.py", validators=[FileAllowed(['py'])])
+    version = StringField("Updated version", validators=[DataRequired()])
 
     def validate_script(self, script):
         if (script.data is not None and not
                 re.match("script.py", script.data.filename)):
             raise ValidationError(
                 "Your script file needs to be called \'script.py\'.")
+
+    def validate_version(self, version):
+        try:
+            int(version.data.replace(".", ""))
+        except Exception:
+            raise ValidationError("Please use only points and digits for the version number. Example: '1.3.2'")
 
     submit = SubmitField("Update Script")
 

--- a/mortimer/models.py
+++ b/mortimer/models.py
@@ -39,12 +39,8 @@ class User(db.Document, UserMixin):
 
 class WebExperiment(db.Document):
     author = db.StringField(required=True)
-    author_mail = db.StringField(required=True)
-    author_mail_from_script = db.StringField()
-    author_mail = db.StringField(required=True)
     title = db.StringField(required=True, unique_with="author")
-    title_from_script = db.StringField()
-    version = db.StringField()
+    version = db.StringField(required=True)
     available_versions = db.ListField(db.StringField())
     date_created = db.DateTimeField(default=datetime.utcnow, required=True)
     last_update = db.DateTimeField(default=datetime.utcnow, required=True)

--- a/mortimer/models.py
+++ b/mortimer/models.py
@@ -39,6 +39,7 @@ class User(db.Document, UserMixin):
 
 class WebExperiment(db.Document):
     author = db.StringField(required=True)
+    author_mail = db.StringField(required=True)
     author_mail_from_script = db.StringField()
     author_mail = db.StringField(required=True)
     title = db.StringField(required=True, unique_with="author")

--- a/mortimer/templates/create_experiment.html
+++ b/mortimer/templates/create_experiment.html
@@ -9,7 +9,7 @@
                 <legend class="border-bottom mb-4">{{ legend }}</legend>
 
                 <div class="form-group">
-                    {{ form.title.label(class="form-control-label") }}
+                    {{ form.title.label(class="form-control-label") }}*
                     {% if form.title.errors %}
                         {{ form.title(class="form-control form-control-lg is-invalid") }} <!-- , placeholder=form.title.label.text -->
 
@@ -21,6 +21,22 @@
                         
                     {% else %}
                     {{ form.title(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+
+                <div class="form-group">
+                    {{ form.version.label(class="form-control-label") }}*
+                    {% if form.version.errors %}
+                        {{ form.version(class="form-control form-control-lg is-invalid") }} <!-- , placeholder=form.version.label.text -->
+
+                        <div class="invalid-feedback">
+                            {% for error in form.version.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                        
+                    {% else %}
+                    {{ form.version(class="form-control form-control-lg") }}
                     {% endif %}
                 </div>
 

--- a/mortimer/templates/experiment.html
+++ b/mortimer/templates/experiment.html
@@ -38,36 +38,6 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-md-3"><small><b>Title Conflict</b></small>:</div><div class="col-md-5">
-        {% if title_unequal %}
-        <span class="badge badge-warning">Different titles in mortimer and script.py. Please change!</span>
-        {% else %}
-        <span class="badge badge-success">All good!</span>
-        {% endif %}
-      </div>
-    </div>
-    {% if title_unequal %}
-    <div class="row">
-      <div class="col-md-3"><small><b>script.py Title</b></small>:</div><div class="col-md-3"><span class="badge badge-light">{{ script_title }}</span></div>
-    </div>
-    {% endif %}
-    {% if experiment.script_name %}
-    <div class="row">
-      <div class="col-md-3"><small><b>Author Conflict</b></small>:</div><div class="col-md-5">
-        {% if author_mail != current_user.email %}
-        <span class="badge badge-warning">Different authors in mortimer and script.py. Please change!</span>
-        {% else %}
-        <span class="badge badge-success">All good!</span>
-        {% endif %}
-      </div>
-    </div>
-    {% endif %}
-    {% if experiment.script_name and author_mail != current_user.email %}
-    <div class="row">
-      <div class="col-md-3"><small><b>Authors</b></small>:</div><div class="col-md-7"><small>Script: </small><span class="badge badge-light">{{ author_mail }}</span><small>, Mortimer: </small><span class="badge badge-light">{{ current_user.email }}</span></div>
-    </div>
-    {% endif %}
-    <div class="row">
       <div class="col-md-3"><small><b>Passsword Protection</b></small>:</div><div class="col-md-5">
         <span class="badge badge-primary">{{ password_protection }}</span>
       </div>
@@ -89,8 +59,6 @@
         {% endfor %}
       </div>
     </div>
-    
-    
     
 
     <h6 class="border-bottom pt-4"><b>Description</b></h6>
@@ -114,7 +82,7 @@
         <a class="btn btn-primary ml-1 mt-2 mb-2" href="{{ url_for('web_experiments.manage_resources', experiment_title=experiment.title, username=experiment.author) }}">Manage Resources</a>
         
         
-        <a class="btn btn-secondary ml-1 mt-2 mb-2" href="{{ url_for('web_experiments.update_experiment', experiment_title=experiment.title, username=experiment.author) }}">Edit</a>
+        <a class="btn btn-secondary ml-1 mt-2 mb-2" href="{{ url_for('web_experiments.update_experiment', exp_title=experiment.title, username=experiment.author) }}">Edit</a>
       
         <button type="button" class="btn btn-danger ml-1 mt-2 mb-2" data-toggle="modal" data-target="#deleteModal">Delete from Mortimer</button>
       

--- a/mortimer/templates/experiment.html
+++ b/mortimer/templates/experiment.html
@@ -164,10 +164,10 @@
     <form method="POST" action="" enctype="multipart/form-data" class="needs-validation" novalidate>
         {{ form.hidden_tag() }}
         <legend class="border-bottom"><b>{{ form.script.label() }}</b></legend>
-        <div class="row">
+        <!-- <div class="row">
           <div class="col-xs ml-3">
           </div>
-          <div class="col-xs ml-2">
+          <div class="col-xs ml-2"> -->
             <div class="form-group">
                     {{ form.script(class="form-control-file") }}
                     {% if form.script.errors %}
@@ -176,10 +176,26 @@
                         {% endfor %}
                     {% endif %}
                 </div>
-          </div>
-          
+          <!-- </div>
+        </div> -->
+        <div class="form-group">
+                    {{ form.version.label(class="form-control-label") }}*
+                    {% if form.version.errors %}
+                        {{ form.version(class="form-control form-control-lg is-invalid") }} <!-- , placeholder=form.version.label.text -->
 
-        </div>
+                        <div class="invalid-feedback">
+                            {% for error in form.version.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                        
+                    {% else %}
+                    {{ form.version(class="form-control form-control-lg", placeholder=experiment.version) }}
+                    {% endif %}
+                    <small id="versionHelpBlock" class="form-text text-muted">
+                      Changing the version number allows you to choose, for which versions of an experiment you want to download data. If you made substantial changes to your experiment, you should change the version.
+                    </small>
+                </div>
         <div class="form-group ml-2">
               {{ form.submit(class="btn btn-primary btn-sm")}}
           </div>

--- a/mortimer/templates/manage_resources.html
+++ b/mortimer/templates/manage_resources.html
@@ -15,7 +15,7 @@
         New Directory
         </button>
         <button type="button" class="btn btn-danger btn mt-1 mb-1" data-toggle="modal" data-target="#deleteModal">Delete All Files</button>
-        <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', experiment_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
+        <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', exp_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
         
         <div class="collapse" id="NewDirectory">
             <form action="{{ url_for('web_experiments.new_directory', experiment_title=experiment.title, username=experiment.author) }}", method="POST">

--- a/mortimer/templates/update_experiment.html
+++ b/mortimer/templates/update_experiment.html
@@ -84,7 +84,7 @@
 </fieldset>
 <div class="form-group">
     {{ form.submit(class="btn btn-outline-primary")}}
-    <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', experiment_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
+    <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', exp_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
 </div>
 </form>
 </div>

--- a/mortimer/templates/update_experiment.html
+++ b/mortimer/templates/update_experiment.html
@@ -80,6 +80,25 @@
                 {% endif %}
             </div>
 
+            <div class="form-group">
+                    {{ form.version.label(class="form-control-label") }}*
+                    {% if form.version.errors %}
+                        {{ form.version(class="form-control form-control-lg is-invalid") }} <!-- , placeholder=form.version.label.text -->
+
+                        <div class="invalid-feedback">
+                            {% for error in form.version.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                        
+                    {% else %}
+                    {{ form.version(class="form-control form-control-lg", placeholder=experiment.version) }}
+                    {% endif %}
+                    <small id="versionHelpBlock" class="form-text text-muted">
+                      Changing the version number allows you to choose, for which versions of an experiment you want to download data. If you made substantial changes to your experiment, you should change the version.
+                    </small>
+                </div>
+
 
 </fieldset>
 <div class="form-group">

--- a/mortimer/templates/upload_resources.html
+++ b/mortimer/templates/upload_resources.html
@@ -25,7 +25,7 @@
         <button id="upload" class="btn btn-primary">Upload</button>
 
         <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.manage_resources', experiment_title=experiment.title, username=experiment.author) }}">Back to Resources Management</a>
-        <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', experiment_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
+        <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', exp_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
 
 </div>
 

--- a/mortimer/templates/user_experiments.html
+++ b/mortimer/templates/user_experiments.html
@@ -15,7 +15,7 @@
             <div class="article-metadata">
               <small class="text-muted">Last Update: <span class="badge badge-light">{{ experiment.last_update.strftime('%Y-%m-%d') }}</span>,  Created: <span class="badge badge-light">{{ experiment.date_created.strftime('%Y-%m-%d') }}</span></small>
             </div>
-            <h3><a class="article-title" href="{{ url_for('web_experiments.experiment', experiment_title=experiment.title, username=experiment.author) }}">{{ experiment.title }}</a><button type="button" class="btn btn-danger btn-sm ml-3 mt-1 float-right" data-toggle="modal" data-target="#deleteModal{{ experiment.title }}">Delete from Mortimer</button></h3>
+            <h3><a class="article-title" href="{{ url_for('web_experiments.experiment', exp_title=experiment.title, username=experiment.author) }}">{{ experiment.title }}</a><button type="button" class="btn btn-danger btn-sm ml-3 mt-1 float-right" data-toggle="modal" data-target="#deleteModal{{ experiment.title }}">Delete from Mortimer</button></h3>
             <!-- <p class="article-content">{{ experiment.script }}</p> -->
           </div>
         </article>

--- a/mortimer/templates/web_export.html
+++ b/mortimer/templates/web_export.html
@@ -94,7 +94,7 @@
             <div class="form-group">
                 {{ form.submit(class="btn btn-outline-primary", id="submit")}}
                 {% if type == "web" %}
-                    <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', experiment_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
+                    <a class="btn btn-outline-primary" href="{{ url_for('web_experiments.experiment', exp_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
                 {% else %}
                     <a class="btn btn-outline-primary" href="{{ url_for('local_experiments.local_experiment', experiment_title=experiment.title, username=experiment.author) }}">Back to Experiment</a>
                 {% endif %}

--- a/mortimer/web_experiments/alfredo.py
+++ b/mortimer/web_experiments/alfredo.py
@@ -137,9 +137,10 @@ def start(expid):
         script.experiment = script.generate_experiment()
 
     # uses the metadata from mortimer for the experiment instance
-    script.experiment.update(name=experiment.title,
+    script.experiment.update(title=experiment.title,
                              version=experiment.version,
-                             author=experiment.author_mail)
+                             author=experiment.author,
+                             uuid=experiment.id)
 
     # start experiment
     script.experiment.start()

--- a/mortimer/web_experiments/alfredo.py
+++ b/mortimer/web_experiments/alfredo.py
@@ -136,6 +136,9 @@ def start(expid):
     else:
         script.experiment = script.generate_experiment()
 
+    script.experiment.update(exp_name=experiment.title, exp_version=experiment.version,
+                             exp_author_mail=experiment.author_mail)
+
     # start experiment
     script.experiment.start()
 

--- a/mortimer/web_experiments/alfredo.py
+++ b/mortimer/web_experiments/alfredo.py
@@ -136,8 +136,10 @@ def start(expid):
     else:
         script.experiment = script.generate_experiment()
 
-    script.experiment.update(exp_name=experiment.title, exp_version=experiment.version,
-                             exp_author_mail=experiment.author_mail)
+    # uses the metadata from mortimer for the experiment instance
+    script.experiment.update(name=experiment.title,
+                             version=experiment.version,
+                             author=experiment.author_mail)
 
     # start experiment
     script.experiment.start()


### PR DESCRIPTION
Mortimer now uses the experiment title, author and version as defined in mortimer for the alfred experiments that are hosted by mortimer. No more double checking between the script.py and mortimer!

Also, for the representation of experiments in mortimer and for the saving of data from experiments in the database, experiments now share the same id. This makes it easy to identify the correct experiment, and allows users to change the title of their experiments as they wish. They will always be able to export their data, because the id remains unchanged.