### PR TITLE
Feature run(generate experiment)

### DIFF
--- a/mortimer/utils.py
+++ b/mortimer/utils.py
@@ -404,8 +404,8 @@ class ScriptString:
 
     def parse(self):
         # removes the run(generate_experiment) command from the end of a script.py allow mortimer to run it
-        p = re.compile(r"(?P<call>run\(generate_experiment\)[\s]*)\Z")
-        self.script = p.sub("# run(generate_experiment)", self.script)
+        p = re.compile(r"(?P<call>run\(generate_experiment\))(?P<comments>([\s]*(#.*)*)*)\Z")
+        self.script = p.sub("# Here, the call to 'run(generate_experiment)' and following comments were removed.", self.script)
 
     def save(self):
         # saves the script to the experiment and to the file system, if changes were made

--- a/mortimer/web_experiments/alfredo.py
+++ b/mortimer/web_experiments/alfredo.py
@@ -11,6 +11,18 @@ import os
 import inspect
 
 
+class Script:
+
+    def __init__(self, experiment=None):
+        self.experiment = experiment
+
+    def generate_experiment(self):
+        pass
+
+    def set_generator(self, generator):
+        self.generate_experiment = generator.__get__(self, Script)
+
+
 def number_of_func_params(func):
     # use in python 3 inspect.signature
     argspec = inspect.getfullargspec(func)
@@ -123,27 +135,44 @@ def start(expid):
 
     os.chdir(experiment.path)
 
-    # create experiment
-    module = import_script(experiment.id)
-    # script.generate_experiment.start()
     try:
-        script = module.script
-    except AttributeError:
-        script = module.Script()
+        module = import_script(experiment.id)
+    except Exception as e:
+        flash("Error during script import:\n'{e}'".format(e=e), 'danger')
+        return redirect(url_for('web_experiments.experiment', username=experiment.author, exp_title=experiment.title))
 
-    if number_of_func_params(script.generate_experiment) > 1:
-        script.experiment = script.generate_experiment(**values)
-    else:
-        script.experiment = script.generate_experiment()
+    try:
+        script = Script()
+        script.set_generator(module.generate_experiment)
+        try:
+            if number_of_func_params(module.generate_experiment) > 1:
+                script.experiment = script.generate_experiment(**values)
+            else:
+                script.experiment = script.generate_experiment()
+        except SyntaxError:
+            flash("The definition of experiment title, type, or version in script.py is deprecated. Please define these parameters in config.conf, when you are working locally. Mortimer will set these parameters for you automatically. In your script.py, just use 'exp = Experiment()'.", "danger")
+            return redirect(url_for('web_experiments.experiment', username=experiment.author, exp_title=experiment.title))
 
-    # uses the metadata from mortimer for the experiment instance
-    script.experiment.update(title=experiment.title,
-                             version=experiment.version,
-                             author=experiment.author,
-                             uuid=experiment.id)
+    except Exception as e:
+        flash("Error during experiment generation:\n'{e}'".format(e=e), 'danger')
+        return redirect(url_for('web_experiments.experiment', username=experiment.author, exp_title=experiment.title))
 
-    # start experiment
-    script.experiment.start()
+    try:
+        # uses the metadata from mortimer for the experiment instance
+        script.experiment.update(title=experiment.title,
+                                 version=experiment.version,
+                                 author=experiment.author,
+                                 uuid=experiment.id)
+    except Exception as e:
+        flash("Error during experiment update:\n'{e}'".format(e=e), 'danger')
+        return redirect(url_for('web_experiments.experiment', username=experiment.author, exp_title=experiment.title))
+
+    try:
+        # start experiment
+        script.experiment.start()
+    except Exception as e:
+        flash("Error during experiment startup:\n'{e}'".format(e=e), 'danger')
+        return redirect(url_for('web_experiments.experiment', username=experiment.author, exp_title=experiment.title))
 
     # set session variables
     experiment_manager.save(sid, script)


### PR DESCRIPTION
This branch implements compatibility with the short `script.py` style implemented in alfred.
Uploaded script.py files are parsed, such that the call to `run(generate_experiment)` is removed.

During the implementation, I also generally cleaned up the processing of uploaded script.py files. Now, it is done using an objected-oriented approach.